### PR TITLE
Support installation of external extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ mopidy_extensions: []
 A list of extensions to install from the package manager.
 
 ```
+mopidy_external_extensions: []
+```
+
+A list of external extensions that are not contained in the repository, but can be obtained with pip.
+
+```
 mopidy_settings: []
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,8 @@
 # List of extensions to install
 mopidy_extensions: []
 
+# List of external extensions to install
+mopidy_external_extensions: []
+
 # List of settings to configure; these are used be the 'ini_file' module.
 mopidy_settings: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,13 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Install mopidy external extensions.
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: mopidy_external_extensions
+  notify: restart mopidy
+
 - name: Configure Mopidy
   ini_file:
     dest: /etc/mopidy/mopidy.conf

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -21,3 +21,9 @@
     state: present
   with_items: mopidy_extensions
   notify: restart mopidy
+
+- name: Ensure pip is available.
+  apt:
+    name: python-pip
+    state: present
+  when: mopidy_external_extensions

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,10 @@
 ---
 
 - hosts: localhost
+  vars:
+    mopidy_extensions:
+      - mopidy-local-sqlite
+    mopidy_external_extensions:
+      - Mopidy-Simple-Webclient
   roles:
     - mopidy


### PR DESCRIPTION
This is currently a separate variable for simplicity, largely due to the
fact that `mopidy_extensions` will be used differently based on the
underlying distribution.

The external extensions are always installed with `pip`, though, so they
seem to make more sense as a separate variable.
