### PR TITLE
Fix the Docker container for running tests on Travis

### DIFF
--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -1,11 +1,13 @@
 FROM ubuntu:14.04
-RUN apt-get update
 
 # Install Ansible
-RUN apt-get install -y software-properties-common git
-RUN apt-add-repository -y ppa:ansible/ansible
-RUN apt-get update
-RUN apt-get install -y ansible
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+ && apt-add-repository -y ppa:ansible/ansible \
+ && apt-get update && apt-get install -y \
+    ansible \
+    git \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -3,6 +3,7 @@ FROM ubuntu:14.04
 # Install Ansible
 RUN apt-get update && apt-get install -y \
     software-properties-common \
+    apt-transport-https \
  && apt-add-repository -y ppa:ansible/ansible \
  && apt-get update && apt-get install -y \
     ansible \


### PR DESCRIPTION
The primary fix is that the apt-transport-https package now seems to be necessary.

Without it, the follow error was occurring when adding the Mopidy repository:

> E:The method driver /usr/lib/apt/methods/https could not be found.

It's possible that this should be a step in the playbook itself, but I'm not convinced
that this occurs outside of Docker. If it comes up again, happy to integrate this
more directly.